### PR TITLE
Fix breaking ) in VFL Guide Alignment to Points

### DIFF
--- a/guides/_posts/2014-01-5-vfl.html
+++ b/guides/_posts/2014-01-5-vfl.html
@@ -192,7 +192,7 @@ Elements can be positioned between points:
 
 {% highlight css %}
 /* VFL */
-@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right])> gap(7);
+@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right]> gap(7);
 
 /* Equivalent CCSS */
 #wall[center-x] + 7 == #poster[left];


### PR DESCRIPTION
Current version doesn't work as written
@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right])> gap(7);

Has an extra paren ")"

Throws following error:
![screen shot 2015-06-10 at 9 51 38 pm](https://cloud.githubusercontent.com/assets/7946707/8100087/f447e932-0fbb-11e5-9848-1ee1ac94bba8.png)

Fixed version without parens works:
@h <#wall[center-x]>-(#poster)-(#clock)-<::window[right]> gap(7);
![screen shot 2015-06-10 at 10 00 16 pm](https://cloud.githubusercontent.com/assets/7946707/8100103/13427988-0fbc-11e5-9e3e-308438a99ebb.png)
